### PR TITLE
Ruff

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -55,6 +55,7 @@ FLOW_DECORATORS_DESC = [
     ("conda_base", ".conda.conda_flow_decorator.CondaFlowDecorator"),
     ("schedule", ".aws.step_functions.schedule_decorator.ScheduleDecorator"),
     ("project", ".project_decorator.ProjectDecorator"),
+    ("ruff", ".linters.ruff_decorator.RuffFlowDecorator"),
 ]
 
 # Add environments here

--- a/metaflow/plugins/linters/ruff_decorator.py
+++ b/metaflow/plugins/linters/ruff_decorator.py
@@ -76,23 +76,6 @@ class Ruff(object):
         stdout, stderr = p.communicate()
 
         return stdout, stderr
-        # # Read both stdout and stderr simultaneously
-        # sel = selectors.DefaultSelector()
-        # sel.register(p.stdout, selectors.EVENT_READ)
-        # sel.register(p.stderr, selectors.EVENT_READ)
-        # ok = True
-        # while ok:
-        #     for key, val1 in sel.select():
-        #         line = key.fileobj.readline()
-        #         if not line:
-        #             ok = False
-        #             break
-
-        #         if key.fileobj is p.stdout:
-        #             yield "stdout", line
-        #         else:
-        #             if "ruff" in line:
-        #                 yield "stderr", line.rsplit("]")[-1][1:]
 
 
 if __name__ == "__main__":

--- a/metaflow/plugins/linters/ruff_decorator.py
+++ b/metaflow/plugins/linters/ruff_decorator.py
@@ -1,0 +1,107 @@
+import inspect
+import logging
+import os
+import subprocess
+import sys
+
+from metaflow.decorators import FlowDecorator
+from metaflow.exception import MetaflowException
+
+logger = logging.getLogger(__name__)
+
+
+class RuffException(MetaflowException):
+    headline = "Ruff is not happy"
+
+
+class RuffFlowDecorator(FlowDecorator):
+
+    name = "ruff"
+
+    defaults = {"options": None}
+
+    def flow_init(
+        self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
+    ):
+        ruff_options = self.attributes.get("options")
+
+        echo(
+            "Running ruff...",
+            fg="magenta",
+            highlight="green",
+        )
+
+        error = False
+
+        fname = inspect.getfile(flow.__class__)
+        stdout, stderr = Ruff().run(fname, ruff_options)
+
+        if stderr:
+            echo(stderr, fg="green", bold=True, indent=True)
+
+        if stdout:
+            echo(
+                stdout,
+                fg="red",
+                bold=True,
+                indent=True,
+            )
+            error = True
+
+        if error:
+            raise RuffException(
+                "Fix ruff warnings listed above or remove the @ruff Flow decorator."
+                " If you specified the `--fix` option,"
+                " this may have been solved automatically"
+            )
+        else:
+            echo("Ruff is happy!", fg="green", bold=True, indent=True)
+
+
+class Ruff(object):
+    def __init__(self):
+        pass
+
+    def run(self, fname, options=None):
+        if options is None:
+            options = []
+
+        ruff = [sys.executable, "-m", "ruff"]
+        args = ["-v", *options, fname]
+        cmd = [*ruff, *args]
+
+        p = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+        )
+        stdout, stderr = p.communicate()
+
+        return stdout, stderr
+        # # Read both stdout and stderr simultaneously
+        # sel = selectors.DefaultSelector()
+        # sel.register(p.stdout, selectors.EVENT_READ)
+        # sel.register(p.stderr, selectors.EVENT_READ)
+        # ok = True
+        # while ok:
+        #     for key, val1 in sel.select():
+        #         line = key.fileobj.readline()
+        #         if not line:
+        #             ok = False
+        #             break
+
+        #         if key.fileobj is p.stdout:
+        #             yield "stdout", line
+        #         else:
+        #             if "ruff" in line:
+        #                 yield "stderr", line.rsplit("]")[-1][1:]
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        fname = __file__
+    else:
+        fname = sys.argv[1]
+
+    print(fname)
+    print(os.getcwd())
+    for type, line in Ruff().run(fname):
+        print(type, line)

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,5 @@ setup(
         [console_scripts]
         metaflow=metaflow.cmd.main_cli:start
       """,
-    install_requires=[
-        "requests",
-        "boto3",
-        "pylint",
-    ],
+    install_requires=["requests", "boto3", "pylint", "ruff"],
 )


### PR DESCRIPTION
Add the ruff linter as a Flow decorator

running the below flow generates the error shown after

```
from metaflow import FlowSpec, step, ruff, Parameter, batch

@ruff
class HelloFlow(FlowSpec):
    @step
    def start(self):
        self.next(self.hello)

    @step
    def hello(self):
        print("Metaflow says: Hi!")
        self.next(self.end)

    @step
    def end(self):
        print("HelloFlow is all done.")


if __name__ == "__main__":
    HelloFlow()
```
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/35522542/216612840-e5934bfd-b631-4e56-97aa-58e1aba22b85.png">

You can also pass CLI options to the decorator, notatbly the `--fix` option, which attempts to automatically fix linting violations:

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/35522542/216613100-b91747f7-940d-46bb-9c22-66a84280fc25.png">


